### PR TITLE
FAQ更新者更新日時、戻るボタン

### DIFF
--- a/app/Models/FAQ.php
+++ b/app/Models/FAQ.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Facades\Auth;
 
 /**
  * FAQモデル
@@ -50,6 +51,7 @@ class FAQ extends Model
         'question',
         'answer',
         'user_id',
+        'updated_by',
         'count',
         'is_active',
         'tags',
@@ -94,6 +96,14 @@ class FAQ extends Model
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * 最終更新者とのリレーション
+     */
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
     }
 
     /**
@@ -271,5 +281,19 @@ class FAQ extends Model
         return $this->inquiries()
             ->wherePivot('created_at', '>=', now()->subMonth())
             ->count();
+    }
+
+    /**
+     * モデルの更新時にupdated_byを自動設定
+     */
+    protected static function boot()
+    {
+        parent::boot();
+
+        static::updating(function ($faq) {
+            if (Auth::check()) {
+                $faq->updated_by = Auth::id();
+            }
+        });
     }
 }

--- a/database/migrations/2025_09_12_094418_add_updated_by_to_faqs_table.php
+++ b/database/migrations/2025_09_12_094418_add_updated_by_to_faqs_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('faqs', function (Blueprint $table) {
+            $table->foreignId('updated_by')->nullable()->after('user_id')->constrained('users')->comment('最終更新者ID');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('faqs', function (Blueprint $table) {
+            $table->dropForeign(['updated_by']);
+            $table->dropColumn('updated_by');
+        });
+    }
+};

--- a/resources/views/livewire/faqs/index.blade.php
+++ b/resources/views/livewire/faqs/index.blade.php
@@ -14,7 +14,7 @@ state([
 $categories = computed(fn() => Category::active()->get());
 
 $faqs = computed(function () {
-    $query = FAQ::with(['category', 'user'])->active();
+    $query = FAQ::with(['category', 'user', 'updatedBy'])->active();
 
     // 検索条件
     if ($this->search) {
@@ -188,7 +188,15 @@ $resetFilters = function () {
                         <div class="flex items-center text-sm text-gray-500 dark:text-gray-400">
                             <span>作成者: {{ $faq->user->name }}</span>
                             <span class="mx-2">•</span>
-                            <span>{{ $faq->created_at->format('Y/m/d H:i') }}</span>
+                            <span>作成: {{ $faq->created_at->format('Y/m/d H:i') }}</span>
+                            @if ($faq->updated_at->ne($faq->created_at))
+                                <span class="mx-2">•</span>
+                                <span>更新: {{ $faq->updated_at->format('Y/m/d H:i') }}</span>
+                                @if ($faq->updatedBy)
+                                    <span class="mx-2">•</span>
+                                    <span>更新者: {{ $faq->updatedBy->name }}</span>
+                                @endif
+                            @endif
                         </div>
                     </div>
 

--- a/resources/views/livewire/faqs/show.blade.php
+++ b/resources/views/livewire/faqs/show.blade.php
@@ -106,6 +106,58 @@ mount(function ($faq_id) {
                 </div>
 
                 <div class="flex items-center gap-2">
+                    <!-- 戻るボタン -->
+                    <a href="{{ route('faqs.index') }}"
+                        class="bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1"
+                        wire:navigate title="FAQ管理に戻る">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                        </svg>
+                        戻る
+                    </a>
+
+                    <!-- コピーボタン群 -->
+                    <div class="flex items-center gap-1 mr-2">
+                        <!-- FAQ URLコピー -->
+                        <button x-data="{ copied: false }"
+                            @click="
+                                navigator.clipboard.writeText('{{ request()->url() }}').then(() => {
+                                    copied = true;
+                                    setTimeout(() => copied = false, 2000);
+                                })
+                            "
+                            class="bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-700 dark:text-blue-300 px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1"
+                            title="FAQ URLをコピー">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
+                                </path>
+                            </svg>
+                            <span x-show="!copied">URL</span>
+                            <span x-show="copied" x-cloak class="text-green-600 dark:text-green-400">コピー完了!</span>
+                        </button>
+
+                        <!-- FAQ IDコピー -->
+                        <button x-data="{ copied: false }"
+                            @click="
+                                navigator.clipboard.writeText('{{ $faq->faq_id }}').then(() => {
+                                    copied = true;
+                                    setTimeout(() => copied = false, 2000);
+                                })
+                            "
+                            class="bg-green-100 hover:bg-green-200 dark:bg-green-900 dark:hover:bg-green-800 text-green-700 dark:text-green-300 px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1"
+                            title="FAQ IDをコピー">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z">
+                                </path>
+                            </svg>
+                            <span x-show="!copied">ID</span>
+                            <span x-show="copied" x-cloak class="text-green-600 dark:text-green-400">コピー完了!</span>
+                        </button>
+                    </div>
+
                     <a href="{{ route('faqs.edit', $faq->faq_id) }}"
                         class="bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-4 py-2 rounded-md text-sm font-medium transition-colors">
                         編集
@@ -175,7 +227,30 @@ mount(function ($faq_id) {
                     @endif
                     <div>
                         <dt class="font-medium text-gray-500 dark:text-gray-400">FAQ ID</dt>
-                        <dd class="mt-1 text-gray-900 dark:text-white">#{{ $faq->faq_id }}</dd>
+                        <dd class="mt-1 text-gray-900 dark:text-white flex items-center gap-2">
+                            <span>#{{ $faq->faq_id }}</span>
+                            <button x-data="{ copied: false }"
+                                @click="
+                                    navigator.clipboard.writeText('{{ $faq->faq_id }}').then(() => {
+                                        copied = true;
+                                        setTimeout(() => copied = false, 2000);
+                                    })
+                                "
+                                class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                                title="IDをコピー">
+                                <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor"
+                                    viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z">
+                                    </path>
+                                </svg>
+                                <svg x-show="copied" x-cloak class="w-4 h-4 text-green-500" fill="none"
+                                    stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M5 13l4 4L19 7"></path>
+                                </svg>
+                            </button>
+                        </dd>
                     </div>
                 </dl>
             </div>

--- a/resources/views/livewire/inquiries/show.blade.php
+++ b/resources/views/livewire/inquiries/show.blade.php
@@ -373,12 +373,66 @@ $insertFaqToResponse = function ($faqId) {
                             @else
                                 <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{{ $inquiry->subject }}
                                 </h1>
-                                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">問い合わせ ID:
-                                    #{{ $inquiry->inquiry_id }}</p>
+                                <div class="mt-1 flex items-center gap-2">
+                                    <p class="text-sm text-gray-500 dark:text-gray-400">問い合わせ ID:
+                                        #{{ $inquiry->inquiry_id }}</p>
+                                    <button x-data="{ copied: false }"
+                                        @click="
+                                            navigator.clipboard.writeText('{{ $inquiry->inquiry_id }}').then(() => {
+                                                copied = true;
+                                                setTimeout(() => copied = false, 2000);
+                                            })
+                                        "
+                                        class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                                        title="IDをコピー">
+                                        <svg x-show="!copied" class="w-4 h-4" fill="none" stroke="currentColor"
+                                            viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z">
+                                            </path>
+                                        </svg>
+                                        <svg x-show="copied" x-cloak class="w-4 h-4 text-green-500" fill="none"
+                                            stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                d="M5 13l4 4L19 7"></path>
+                                        </svg>
+                                    </button>
+                                </div>
                             @endif
                         </div>
                         <div class="flex items-center gap-2 ml-4">
                             @if (!$editing_mode)
+                                <!-- 戻るボタン -->
+                                <a href="{{ route('inquiries.index') }}"
+                                    class="bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1"
+                                    wire:navigate title="問い合わせ管理に戻る">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                                    </svg>
+                                    戻る
+                                </a>
+
+                                <!-- コピーボタン -->
+                                <button x-data="{ copied: false }"
+                                    @click="
+                                        navigator.clipboard.writeText('{{ request()->url() }}').then(() => {
+                                            copied = true;
+                                            setTimeout(() => copied = false, 2000);
+                                        })
+                                    "
+                                    class="bg-blue-100 hover:bg-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 text-blue-700 dark:text-blue-300 px-3 py-2 rounded-md text-sm font-medium transition-colors flex items-center gap-1"
+                                    title="問い合わせURLをコピー">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1">
+                                        </path>
+                                    </svg>
+                                    <span x-show="!copied">URL</span>
+                                    <span x-show="copied" x-cloak
+                                        class="text-green-600 dark:text-green-400">コピー完了!</span>
+                                </button>
+
                                 <button wire:click="startEditing"
                                     class="bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300 px-3 py-2 rounded-md text-sm font-medium transition-colors">
                                     <svg class="w-4 h-4 mr-1 inline" fill="none" stroke="currentColor"


### PR DESCRIPTION

FAQ詳細画面にコピーボタン機能を実装完了！
FAQ詳細画面と問い合わせ詳細画面に、URLとIDをワンクリックでコピーできる機能を追加しました。
 実装した機能
FAQ詳細画面 (resources/views/livewire/faqs/show.blade.php)
ヘッダー部分のコピーボタン:
FAQ URLコピーボタン (青色): ページのURLをコピー
FAQ IDコピーボタン (緑色): FAQ IDをコピー
メタ情報セクションのIDコピー:
FAQ ID表示の横に小さなコピーボタン
クリックでIDをコピー、成功時にチェックマークアイコン表示
問い合わせ詳細画面 (resources/views/livewire/inquiries/show.blade.php)
ヘッダー部分のURLコピーボタン:
問い合わせURLコピーボタン (青色): ページのURLをコピー
IDコピーボタン:
問い合わせID表示の横に小さなコピーボタン
クリックでIDをコピー、成功時にチェックマークアイコン表示
---
戻る」ボタンの実装完了！
問い合わせ詳細画面とFAQ詳細画面の両方に「戻る」ボタンを追加しました。
🎯 実装した機能
問い合わせ詳細画面 (resources/views/livewire/inquiries/show.blade.php)
ヘッダー部分に「戻る」ボタンを追加
クリックで問い合わせ管理ページ (inquiries.index) に遷移
FAQ詳細画面 (resources/views/livewire/faqs/show.blade.php)
ヘッダー部分に「戻る」ボタンを追加
クリックでFAQ管理ページ (faqs.index) に遷移
Livewire Navigate使用
SPAライクな高速ページ遷移
ページ全体のリロードなし
ブラウザの戻るボタンとも連携
---
最終更新者表示: FAQ一覧に最終更新者と更新日時
FAQ一覧に最終更新者と更新日時表示機能を実装完了！
FAQ一覧に最終更新者と更新日時を表示する機能を完全に実装しました。
🎯 実装した機能
1. データベース構造の拡張
新しいカラム追加: faqsテーブルにupdated_byカラムを追加
外部キー制約: usersテーブルとの関連付け
既存データの更新: 既存のFAQデータにupdated_byを設定
2. FAQモデルの拡張
新しいリレーション: updatedBy()メソッドで最終更新者を取得
自動更新機能: FAQ更新時にupdated_byを自動設定
fillable属性: updated_byを追加
3. FAQ一覧画面の表示改善
作成情報: 作成者と作成日時
更新情報: 更新日時と最終更新者（更新がある場合のみ表示）
条件表示: 作成日時と更新日時が異なる場合のみ更新情報を表示