### PR TITLE
FAQから紐づけて新規登録機能修正とダッシュボードの修正

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -65,7 +65,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => 'Asia/Tokyo',
 
     /*
     |--------------------------------------------------------------------------
@@ -78,7 +78,7 @@ return [
     |
     */
 
-    'locale' => env('APP_LOCALE', 'en'),
+    'locale' => env('APP_LOCALE', 'ja'),
 
     'fallback_locale' => env('APP_FALLBACK_LOCALE', 'en'),
 

--- a/resources/views/livewire/dashboard/index.blade.php
+++ b/resources/views/livewire/dashboard/index.blade.php
@@ -11,10 +11,10 @@ $stats = computed(function () {
     $endOfMonth = $now->copy()->endOfMonth();
 
     return [
-        // 今月の問い合わせ総数（クローズ数）
-        'monthly_closed_inquiries' => Inquiry::where('status', 'closed')
-            ->whereBetween('received_at', [$startOfMonth, $endOfMonth])
-            ->count(),
+        // 本日の問い合わせ総数
+        'today_total_inquiries' => Inquiry::whereDate('received_at', $now->toDateString())->count(),
+        // 本日のクローズ数
+        'today_closed_inquiries' => Inquiry::where('status', 'closed')->whereDate('received_at', $now->toDateString())->count(),
         // 未対応（クローズ以外）
         'unclosed_inquiries' => Inquiry::whereNotIn('status', ['closed'])->count(),
         // 回答作成済（completed）
@@ -80,8 +80,9 @@ $loadHotFaqs = function () {
 
     <!-- 統計カード -->
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-        <!-- 今月の問い合わせ総数（クローズ数） -->
-        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+        <!-- 本日の対応状況 -->
+        <a href="{{ route('inquiries.today') }}"
+            class="block bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 hover:shadow-md transition-shadow cursor-pointer">
             <div class="flex items-center">
                 <div class="p-3 rounded-full bg-green-100 dark:bg-green-900">
                     <svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor"
@@ -91,14 +92,19 @@ $loadHotFaqs = function () {
                     </svg>
                 </div>
                 <div class="ml-4">
-                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">今月のクローズ数</p>
+                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">本日の対応状況</p>
                     <p class="text-2xl font-bold text-gray-900 dark:text-white">
-                        {{ number_format($this->stats['monthly_closed_inquiries']) }}</p>
-                    <p class="text-xs text-gray-500 dark:text-gray-400">今月総数:
-                        {{ number_format($this->stats['monthly_total_inquiries']) }}</p>
+                        {{ number_format($this->stats['today_closed_inquiries']) }}</p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">本日総数:
+                        {{ number_format($this->stats['today_total_inquiries']) }}</p>
+                </div>
+                <div class="ml-auto">
+                    <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                    </svg>
                 </div>
             </div>
-        </div>
+        </a>
 
         <!-- 未対応問い合わせ（クローズ以外） -->
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
@@ -201,8 +207,8 @@ $loadHotFaqs = function () {
                 <div class="flex-shrink-0">
                     <div
                         class="w-10 h-10 bg-yellow-100 dark:bg-yellow-900 rounded-full flex items-center justify-center">
-                        <svg class="w-5 h-5 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor"
-                            viewBox="0 0 24 24">
+                        <svg class="w-5 h-5 text-yellow-600 dark:text-yellow-400" fill="none"
+                            stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                 d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                         </svg>

--- a/resources/views/livewire/inquiries/create.blade.php
+++ b/resources/views/livewire/inquiries/create.blade.php
@@ -39,7 +39,6 @@ mount(function () {
             $this->linked_faq = $faq;
             $this->linked_faq_ids = [$faq->faq_id];
             $this->category_id = $faq->category_id;
-            $this->content = $faq->answer;
         }
     }
 });

--- a/resources/views/livewire/inquiries/today.blade.php
+++ b/resources/views/livewire/inquiries/today.blade.php
@@ -1,0 +1,202 @@
+<?php
+
+use App\Models\Inquiry;
+use function Livewire\Volt\{computed, state, mount};
+
+$todayInquiries = computed(function () {
+    return Inquiry::with(['category', 'assignedUser'])
+        ->whereDate('received_at', now()->toDateString())
+        ->orderBy('received_at', 'desc')
+        ->get();
+});
+
+$todayStats = computed(function () {
+    $today = now()->toDateString();
+
+    return [
+        'total' => Inquiry::whereDate('received_at', $today)->count(),
+        'closed' => Inquiry::whereDate('received_at', $today)->where('status', 'closed')->count(),
+    ];
+});
+
+?>
+
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-8">
+        <div class="flex items-center justify-between">
+            <div>
+                <h1 class="text-3xl font-bold text-gray-900 dark:text-white">本日の問い合わせ</h1>
+                <p class="mt-2 text-gray-600 dark:text-gray-400">
+                    {{ now()->format('Y年n月j日') }}に受信した問い合わせ一覧
+                </p>
+            </div>
+            <a href="{{ route('dashboard') }}"
+                class="inline-flex items-center px-4 py-2 bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+                <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                </svg>
+                ダッシュボードに戻る
+            </a>
+        </div>
+    </div>
+
+    <!-- 統計情報 -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+            <div class="flex items-center">
+                <div class="p-3 rounded-full bg-blue-100 dark:bg-blue-900">
+                    <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor"
+                        viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M3 8l7.89 7.89a2 2 0 002.83 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">本日総数</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                        {{ number_format($this->todayStats['total']) }}件
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+            <div class="flex items-center">
+                <div class="p-3 rounded-full bg-green-100 dark:bg-green-900">
+                    <svg class="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor"
+                        viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                </div>
+                <div class="ml-4">
+                    <p class="text-sm font-medium text-gray-500 dark:text-gray-400">クローズ数</p>
+                    <p class="text-2xl font-bold text-gray-900 dark:text-white">
+                        {{ number_format($this->todayStats['closed']) }}件
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- 問い合わせ一覧 -->
+    <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700">
+        <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">問い合わせ一覧</h2>
+        </div>
+
+        @if ($this->todayInquiries->count() > 0)
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead class="bg-gray-50 dark:bg-gray-900">
+                        <tr>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                受信日時
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                顧客ID
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                都道府県
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                属性
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                件名
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                ステータス
+                            </th>
+                            <th
+                                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+                                担当者
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                        @foreach ($this->todayInquiries as $inquiry)
+                            <tr class="hover:bg-gray-50 dark:hover:bg-gray-700">
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                    {{ $inquiry->received_at->format('H:i') }}
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                    {{ $inquiry->customer_id ?? '-' }}
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                    {{ $inquiry->prefecture ?? '-' }}
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                    {{ $inquiry->user_attribute ?? '-' }}
+                                </td>
+                                <td class="px-6 py-4 text-sm text-gray-900 dark:text-gray-100">
+                                    <a href="{{ route('inquiries.show', $inquiry->inquiry_id) }}"
+                                        class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 truncate block max-w-xs">
+                                        {{ $inquiry->subject }}
+                                    </a>
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    @switch($inquiry->status)
+                                        @case('pending')
+                                            <span
+                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+                                                未対応
+                                            </span>
+                                        @break
+
+                                        @case('in_progress')
+                                            <span
+                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+                                                対応中
+                                            </span>
+                                        @break
+
+                                        @case('completed')
+                                            <span
+                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+                                                回答済
+                                            </span>
+                                        @break
+
+                                        @case('closed')
+                                            <span
+                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+                                                クローズ
+                                            </span>
+                                        @break
+
+                                        @case('no_response')
+                                            <span
+                                                class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200">
+                                                無回答
+                                            </span>
+                                        @break
+                                    @endswitch
+                                </td>
+                                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
+                                    {{ $inquiry->assignedUser->name ?? '-' }}
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @else
+            <div class="p-6 text-center">
+                <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                <h3 class="mt-2 text-sm font-medium text-gray-900 dark:text-gray-100">本日の問い合わせはありません</h3>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">今日はまだ問い合わせが受信されていません。</p>
+            </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,6 +20,7 @@ Route::middleware(['auth'])->group(function () {
     // 問い合わせ管理
     Volt::route('inquiries', 'inquiries.index')->name('inquiries.index');
     Volt::route('inquiries/create', 'inquiries.create')->name('inquiries.create');
+    Volt::route('inquiries/today', 'inquiries.today')->name('inquiries.today');
     Volt::route('inquiries/{inquiry_id}', 'inquiries.show')->name('inquiries.show');
 
     // カテゴリ管理

--- a/tests/Feature/DashboardTodayInquiriesTest.php
+++ b/tests/Feature/DashboardTodayInquiriesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\User;
+use App\Models\Inquiry;
+use App\Models\Category;
+
+test('dashboard shows today inquiries statistics', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 今日の問い合わせを作成（クローズ済み）
+    $closedInquiry = Inquiry::factory()->create([
+        'received_at' => now(),
+        'status' => 'closed',
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    // 今日の問い合わせを作成（未対応）
+    $pendingInquiry = Inquiry::factory()->create([
+        'received_at' => now(),
+        'status' => 'pending',
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    $response = $this->get(route('dashboard'));
+    $response->assertStatus(200);
+    $response->assertSee('本日の対応状況');
+    $response->assertSee('1'); // クローズ数
+    $response->assertSee('2'); // 本日総数
+});
+
+test('dashboard today inquiries card links to today inquiries page', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $response = $this->get(route('dashboard'));
+    $response->assertStatus(200);
+    $response->assertSee('href="' . route('inquiries.today') . '"', false);
+});
+
+test('dashboard shows correct today statistics when no inquiries', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $response = $this->get(route('dashboard'));
+    $response->assertStatus(200);
+    $response->assertSee('本日の対応状況');
+    $response->assertSee('0'); // クローズ数
+    $response->assertSee('0'); // 本日総数
+});

--- a/tests/Feature/FaqInquiryLinkTest.php
+++ b/tests/Feature/FaqInquiryLinkTest.php
@@ -67,8 +67,6 @@ test('FAQ ID付きで問い合わせ新規登録画面でFAQ情報が表示さ�
 
     // フォームの初期値が設定されていることを確認
     $response->assertSee('value="' . $this->faq->category_id . '"', false);
-    // 詳細内容にFAQの回答が設定されていることを確認
-    $response->assertSee($this->faq->answer, false);
 });
 
 test('存在しないFAQ IDで問い合わせ新規登録画面にアクセスしてもエラーにならない', function () {

--- a/tests/Feature/InquiriesTodayTest.php
+++ b/tests/Feature/InquiriesTodayTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use App\Models\User;
+use App\Models\Inquiry;
+use App\Models\Category;
+
+test('guests are redirected to the login page when accessing today inquiries', function () {
+    $response = $this->get(route('inquiries.today'));
+    $response->assertRedirect(route('login'));
+});
+
+test('authenticated users can visit today inquiries page', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $response = $this->get(route('inquiries.today'));
+    $response->assertStatus(200);
+    $response->assertSee('本日の問い合わせ');
+});
+
+test('today inquiries page shows today inquiries', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 今日の問い合わせを作成
+    $todayInquiry = Inquiry::factory()->create([
+        'received_at' => now(),
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    // 昨日の問い合わせを作成（表示されないはず）
+    $yesterdayInquiry = Inquiry::factory()->create([
+        'received_at' => now()->subDay(),
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    $response = $this->get(route('inquiries.today'));
+    $response->assertStatus(200);
+    $response->assertSee($todayInquiry->subject);
+    $response->assertDontSee($yesterdayInquiry->subject);
+});
+
+test('today inquiries page shows correct statistics', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 今日の問い合わせを作成（クローズ済み）
+    $closedInquiry = Inquiry::factory()->create([
+        'received_at' => now(),
+        'status' => 'closed',
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    // 今日の問い合わせを作成（未対応）
+    $pendingInquiry = Inquiry::factory()->create([
+        'received_at' => now(),
+        'status' => 'pending',
+        'category_id' => $category->id,
+        'created_user_id' => $user->id,
+    ]);
+
+    $response = $this->get(route('inquiries.today'));
+    $response->assertStatus(200);
+    $response->assertSee('2件'); // 本日総数
+    $response->assertSee('1件'); // クローズ数
+});
+
+test('today inquiries page shows empty state when no inquiries', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $response = $this->get(route('inquiries.today'));
+    $response->assertStatus(200);
+    $response->assertSee('本日の問い合わせはありません');
+    $response->assertSee('0件'); // 本日総数
+    $response->assertSee('0件'); // クローズ数
+});

--- a/tests/Feature/InquiryCreateTimezoneTest.php
+++ b/tests/Feature/InquiryCreateTimezoneTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Models\User;
+use App\Models\Category;
+use Livewire\Volt\Volt;
+
+test('inquiry creation with today date works with Asia/Tokyo timezone', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 今日の日付で問い合わせを作成
+    $today = now()->format('Y-m-d H:i:s');
+
+    $response = Volt::test('inquiries.create')
+        ->set('sender_email', 'test@example.com')
+        ->set('subject', 'テスト問い合わせ')
+        ->set('content', 'テスト内容')
+        ->set('received_at', $today)
+        ->set('category_id', $category->id)
+        ->call('save');
+
+    $response->assertHasNoErrors();
+    $response->assertRedirect();
+});
+
+test('inquiry creation with future date fails validation', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 未来の日付で問い合わせを作成（エラーになるはず）
+    $futureDate = now()->addDay()->format('Y-m-d H:i:s');
+
+    $response = Volt::test('inquiries.create')
+        ->set('sender_email', 'test@example.com')
+        ->set('subject', 'テスト問い合わせ')
+        ->set('content', 'テスト内容')
+        ->set('received_at', $futureDate)
+        ->set('category_id', $category->id)
+        ->call('save');
+
+    $response->assertHasErrors(['received_at']);
+});
+
+test('inquiry creation with yesterday date works', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $category = Category::factory()->create();
+
+    // 昨日の日付で問い合わせを作成
+    $yesterday = now()->subDay()->format('Y-m-d H:i:s');
+
+    $response = Volt::test('inquiries.create')
+        ->set('sender_email', 'test@example.com')
+        ->set('subject', 'テスト問い合わせ')
+        ->set('content', 'テスト内容')
+        ->set('received_at', $yesterday)
+        ->set('category_id', $category->id)
+        ->call('save');
+
+    $response->assertHasNoErrors();
+    $response->assertRedirect();
+});


### PR DESCRIPTION
- 修正内容

1. 詳細内容（問い合わせ内容）の自動設定を削除
2. 問い合わせ内容フィールドは空の状態で開始
3. ユーザーが自由に問い合わせ内容を入力できる
4. 現在の動作
5. FAQ詳細画面から「問い合わせ登録」ボタンをクリックすると：
6. 自動設定される項目：
7. カテゴリID（FAQと同じカテゴリ）
8. 紐づけFAQ ID
9. 手動入力が必要な項目：
10. 件名（メールの件名）
11. 要約（問い合わせの要約）
12. 詳細内容（問い合わせ内容）
13. その他の基本情報


- ダッシュボードの修正
1. ダッシュボードの修正
「今月のクローズ数」 → 「本日の対応状況」 に変更
本日総数とクローズ数を表示
クリック可能なカードとして実装し、本日受信した問い合わせ一覧ページに遷移
2. 本日受信した問い合わせ一覧ページの作成
新しいページ /inquiries/today を作成
表示項目：受信日時、顧客ID、都道府県、属性、件名、ステータス、担当者
本日総数とクローズ数の統計情報を表示
レスポンシブなテーブルレイアウト
3. ルーティングの設定
inquiries.today ルートを追加
認証が必要なページとして設定
主な機能
✅ ダッシュボードで本日の対応状況を表示
✅ クリックで本日受信した問い合わせ一覧に遷移
✅ 一覧ページで必要な項目を全て表示
✅ 統計情報（本日総数・クローズ数）を表示
✅ レスポンシブデザイン対応
✅ 認証・認可の適切な実装
✅ 包括的なテストカバレッジ